### PR TITLE
fix warnings and compilation errors

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,8 +4,7 @@ project(cofusion)
 set(CMAKE_CXX_STANDARD 14)
 
 # Warnings / Errors
-add_compile_options(-Wall -Werror -Wno-unused-variable -Wno-write-strings
-  -Wno-deprecated-declarations)
+add_compile_options(-Wall -Werror -Wno-write-strings -Wno-deprecated-declarations)
 
 # Don't follow symlinks when FILE GLOB_RECURSE (and don't warn)
 cmake_policy(SET CMP0009 NEW)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,9 +4,8 @@ project(cofusion)
 set(CMAKE_CXX_STANDARD 14)
 
 # Warnings / Errors
-add_compile_options(-Wall -Wno-unused-function -Wno-unused-variable
-  -Wno-unused-but-set-variable -Wno-unused-but-set-variable -Wno-write-strings
-  -Wno-deprecated -Wno-deprecated-declarations -Werror -Wno-unknown-pragmas)
+add_compile_options(-Wall -Werror -Wno-unused-variable -Wno-write-strings
+  -Wno-deprecated -Wno-deprecated-declarations)
 
 # Don't follow symlinks when FILE GLOB_RECURSE (and don't warn)
 cmake_policy(SET CMP0009 NEW)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@ set(CMAKE_CXX_STANDARD 14)
 
 # Warnings / Errors
 add_compile_options(-Wall -Werror -Wno-unused-variable -Wno-write-strings
-  -Wno-deprecated -Wno-deprecated-declarations)
+  -Wno-deprecated-declarations)
 
 # Don't follow symlinks when FILE GLOB_RECURSE (and don't warn)
 cmake_policy(SET CMP0009 NEW)

--- a/Core/CMakeLists.txt
+++ b/Core/CMakeLists.txt
@@ -102,7 +102,6 @@ if(CMAKE_BUILD_TYPE MATCHES Debug)
 else(CMAKE_BUILD_TYPE MATCHES Release)
     message(STATUS "Release build.")
     add_compile_options(-O3)
-    add_compile_options(-Wno-maybe-uninitialized)
 endif(CMAKE_BUILD_TYPE MATCHES Debug)
 
 add_library(${PROJECT_NAME} SHARED

--- a/Core/CMakeLists.txt
+++ b/Core/CMakeLists.txt
@@ -138,9 +138,6 @@ target_link_libraries(${PROJECT_NAME}
 
 set_target_properties(${PROJECT_NAME} PROPERTIES INTERFACE_LINK_LIBRARIES "")
 
-# deactivate 'class-memaccess' error for direct memcpy of list of 'Eigen::Vector4f'
-target_compile_options(${PROJECT_NAME} PRIVATE "-Wno-error=class-memaccess")
-
 
 target_include_directories(${PROJECT_NAME} PUBLIC
     $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}>

--- a/Core/CoFusion.cpp
+++ b/Core/CoFusion.cpp
@@ -753,6 +753,7 @@ void CoFusion::savePly() {
   };
 
   for (auto& m : models) exportModelPLY(m);
+  for (auto& m : inactiveModels) exportModelPLY(m);
 }
 
 void CoFusion::exportPoses() {

--- a/Core/CoFusion.h
+++ b/Core/CoFusion.h
@@ -39,7 +39,6 @@
 #include <list>
 #include <iomanip>
 #include <memory>
-#include <pangolin/gl/glcuda.h>
 
 class CoFusion {
  public:

--- a/Core/Cuda/reduce.cu
+++ b/Core/Cuda/reduce.cu
@@ -53,32 +53,6 @@
 #include "convenience.cuh"
 #include "operators.cuh"
 
-#if __CUDA_ARCH__ < 300 || __CUDA_ARCH__ > 700
-__inline__ __device__
-float __shfl_down(float val, int offset, int width = 32)
-{
-    static __shared__ float shared[MAX_THREADS];
-    int lane = threadIdx.x % 32;
-    shared[threadIdx.x] = val;
-    __syncthreads();
-    val = (lane + offset < width) ? shared[threadIdx.x + offset] : 0;
-    __syncthreads();
-    return val;
-}
-
-__inline__ __device__
-int __shfl_down(int val, int offset, int width = 32)
-{
-    static __shared__ int shared[MAX_THREADS];
-    int lane = threadIdx.x % 32;
-    shared[threadIdx.x] = val;
-    __syncthreads();
-    val = (lane + offset < width) ? shared[threadIdx.x + offset] : 0;
-    __syncthreads();
-    return val;
-}
-#endif
-
 #if __CUDA_ARCH__ < 350
 template<typename T>
 __device__ __forceinline__ T __ldg(const T* ptr)
@@ -91,41 +65,41 @@ __inline__  __device__ JtJJtrSE3 warpReduceSum(JtJJtrSE3 val)
 {
     for(int offset = warpSize / 2; offset > 0; offset /= 2)
     {
-        val.aa += __shfl_down(val.aa, offset);
-        val.ab += __shfl_down(val.ab, offset);
-        val.ac += __shfl_down(val.ac, offset);
-        val.ad += __shfl_down(val.ad, offset);
-        val.ae += __shfl_down(val.ae, offset);
-        val.af += __shfl_down(val.af, offset);
-        val.ag += __shfl_down(val.ag, offset);
+        val.aa += __shfl_down_sync(0xFFFFFFFF, val.aa, offset);
+        val.ab += __shfl_down_sync(0xFFFFFFFF, val.ab, offset);
+        val.ac += __shfl_down_sync(0xFFFFFFFF, val.ac, offset);
+        val.ad += __shfl_down_sync(0xFFFFFFFF, val.ad, offset);
+        val.ae += __shfl_down_sync(0xFFFFFFFF, val.ae, offset);
+        val.af += __shfl_down_sync(0xFFFFFFFF, val.af, offset);
+        val.ag += __shfl_down_sync(0xFFFFFFFF, val.ag, offset);
 
-        val.bb += __shfl_down(val.bb, offset);
-        val.bc += __shfl_down(val.bc, offset);
-        val.bd += __shfl_down(val.bd, offset);
-        val.be += __shfl_down(val.be, offset);
-        val.bf += __shfl_down(val.bf, offset);
-        val.bg += __shfl_down(val.bg, offset);
+        val.bb += __shfl_down_sync(0xFFFFFFFF, val.bb, offset);
+        val.bc += __shfl_down_sync(0xFFFFFFFF, val.bc, offset);
+        val.bd += __shfl_down_sync(0xFFFFFFFF, val.bd, offset);
+        val.be += __shfl_down_sync(0xFFFFFFFF, val.be, offset);
+        val.bf += __shfl_down_sync(0xFFFFFFFF, val.bf, offset);
+        val.bg += __shfl_down_sync(0xFFFFFFFF, val.bg, offset);
 
-        val.cc += __shfl_down(val.cc, offset);
-        val.cd += __shfl_down(val.cd, offset);
-        val.ce += __shfl_down(val.ce, offset);
-        val.cf += __shfl_down(val.cf, offset);
-        val.cg += __shfl_down(val.cg, offset);
+        val.cc += __shfl_down_sync(0xFFFFFFFF, val.cc, offset);
+        val.cd += __shfl_down_sync(0xFFFFFFFF, val.cd, offset);
+        val.ce += __shfl_down_sync(0xFFFFFFFF, val.ce, offset);
+        val.cf += __shfl_down_sync(0xFFFFFFFF, val.cf, offset);
+        val.cg += __shfl_down_sync(0xFFFFFFFF, val.cg, offset);
 
-        val.dd += __shfl_down(val.dd, offset);
-        val.de += __shfl_down(val.de, offset);
-        val.df += __shfl_down(val.df, offset);
-        val.dg += __shfl_down(val.dg, offset);
+        val.dd += __shfl_down_sync(0xFFFFFFFF, val.dd, offset);
+        val.de += __shfl_down_sync(0xFFFFFFFF, val.de, offset);
+        val.df += __shfl_down_sync(0xFFFFFFFF, val.df, offset);
+        val.dg += __shfl_down_sync(0xFFFFFFFF, val.dg, offset);
 
-        val.ee += __shfl_down(val.ee, offset);
-        val.ef += __shfl_down(val.ef, offset);
-        val.eg += __shfl_down(val.eg, offset);
+        val.ee += __shfl_down_sync(0xFFFFFFFF, val.ee, offset);
+        val.ef += __shfl_down_sync(0xFFFFFFFF, val.ef, offset);
+        val.eg += __shfl_down_sync(0xFFFFFFFF, val.eg, offset);
 
-        val.ff += __shfl_down(val.ff, offset);
-        val.fg += __shfl_down(val.fg, offset);
+        val.ff += __shfl_down_sync(0xFFFFFFFF, val.ff, offset);
+        val.fg += __shfl_down_sync(0xFFFFFFFF, val.fg, offset);
 
-        val.residual += __shfl_down(val.residual, offset);
-        val.inliers += __shfl_down(val.inliers, offset);
+        val.residual += __shfl_down_sync(0xFFFFFFFF, val.residual, offset);
+        val.inliers += __shfl_down_sync(0xFFFFFFFF, val.inliers, offset);
     }
 
     return val;
@@ -188,20 +162,20 @@ __inline__  __device__ JtJJtrSO3 warpReduceSum(JtJJtrSO3 val)
 {
     for(int offset = warpSize / 2; offset > 0; offset /= 2)
     {
-        val.aa += __shfl_down(val.aa, offset);
-        val.ab += __shfl_down(val.ab, offset);
-        val.ac += __shfl_down(val.ac, offset);
-        val.ad += __shfl_down(val.ad, offset);
+        val.aa += __shfl_down_sync(0xFFFFFFFF, val.aa, offset);
+        val.ab += __shfl_down_sync(0xFFFFFFFF, val.ab, offset);
+        val.ac += __shfl_down_sync(0xFFFFFFFF, val.ac, offset);
+        val.ad += __shfl_down_sync(0xFFFFFFFF, val.ad, offset);
 
-        val.bb += __shfl_down(val.bb, offset);
-        val.bc += __shfl_down(val.bc, offset);
-        val.bd += __shfl_down(val.bd, offset);
+        val.bb += __shfl_down_sync(0xFFFFFFFF, val.bb, offset);
+        val.bc += __shfl_down_sync(0xFFFFFFFF, val.bc, offset);
+        val.bd += __shfl_down_sync(0xFFFFFFFF, val.bd, offset);
 
-        val.cc += __shfl_down(val.cc, offset);
-        val.cd += __shfl_down(val.cd, offset);
+        val.cc += __shfl_down_sync(0xFFFFFFFF, val.cc, offset);
+        val.cd += __shfl_down_sync(0xFFFFFFFF, val.cd, offset);
 
-        val.residual += __shfl_down(val.residual, offset);
-        val.inliers += __shfl_down(val.inliers, offset);
+        val.residual += __shfl_down_sync(0xFFFFFFFF, val.residual, offset);
+        val.inliers += __shfl_down_sync(0xFFFFFFFF, val.inliers, offset);
     }
 
     return val;
@@ -690,8 +664,8 @@ __inline__  __device__ int2 warpReduceSum(int2 val)
 {
     for(int offset = warpSize / 2; offset > 0; offset /= 2)
     {
-        val.x += __shfl_down(val.x, offset);
-        val.y += __shfl_down(val.y, offset);
+        val.x += __shfl_down_sync(0xFFFFFFFF, val.x, offset);
+        val.y += __shfl_down_sync(0xFFFFFFFF, val.y, offset);
     }
 
     return val;

--- a/Core/Ferns.cpp
+++ b/Core/Ferns.cpp
@@ -79,8 +79,9 @@ bool Ferns::addFrame(GPUTexture* imageTexture, GPUTexture* vertexTexture, GPUTex
   resize.vertex(vertexTexture, verts);
   resize.vertex(normalTexture, norms);
 
-  Frame* frame = new Frame(num, frames.size(), pose, srcTime, width * height, (unsigned char*)img.data, (Eigen::Vector4f*)verts.data,
-                           (Eigen::Vector4f*)norms.data);
+  Frame* frame = new Frame(num, frames.size(), pose, srcTime, width * height, (unsigned char*)img.data,
+                           std::vector<Eigen::Vector4f>(verts.data, verts.data + (width * height)),
+                           std::vector<Eigen::Vector4f>(norms.data, norms.data + (width * height)));
 
   int* coOccurrences = new int[frames.size()];
 
@@ -202,10 +203,10 @@ Eigen::Matrix4f Ferns::findFrame(std::vector<SurfaceConstraint>& constraints, co
   if (minId != -1 && blockHDAware(frame, frames.at(minId)) > 0.3) {
     Eigen::Matrix4f fernPose = frames.at(minId)->pose;
 
-    vertFern.texture->Upload(frames.at(minId)->initVerts, GL_RGBA, GL_FLOAT);
+    vertFern.texture->Upload(frames.at(minId)->initVerts.data(), GL_RGBA, GL_FLOAT);
     vertCurrent.texture->Upload(vertSmall.data, GL_RGBA, GL_FLOAT);
 
-    normFern.texture->Upload(frames.at(minId)->initNorms, GL_RGBA, GL_FLOAT);
+    normFern.texture->Upload(frames.at(minId)->initNorms.data(), GL_RGBA, GL_FLOAT);
     normCurrent.texture->Upload(normSmall.data, GL_RGBA, GL_FLOAT);
 
     //        colorFern.texture->Upload(frames.at(minId)->initRgb, GL_RGB, GL_UNSIGNED_BYTE);

--- a/Core/Ferns.h
+++ b/Core/Ferns.h
@@ -63,8 +63,8 @@ class Ferns {
   class Frame {
    public:
     Frame(int n, int id, const Eigen::Matrix4f& pose, const int srcTime, const int numPixels, unsigned char* rgb = 0,
-          Eigen::Vector4f* verts = 0, Eigen::Vector4f* norms = 0)
-        : goodCodes(0), id(id), pose(pose), srcTime(srcTime), initRgb(rgb), initVerts(verts), initNorms(norms) {
+          const std::vector<Eigen::Vector4f> &verts = {}, const std::vector<Eigen::Vector4f> &norms = {})
+        : goodCodes(0), id(id), pose(pose), srcTime(srcTime), initRgb(rgb) {
       codes = new unsigned char[n];
 
       if (rgb) {
@@ -72,14 +72,12 @@ class Ferns {
         memcpy(this->initRgb, rgb, numPixels * 3);
       }
 
-      if (verts) {
-        this->initVerts = new Eigen::Vector4f[numPixels];
-        memcpy(this->initVerts, verts, numPixels * sizeof(Eigen::Vector4f));
+      if (!verts.empty()) {
+        this->initVerts = verts;
       }
 
-      if (norms) {
-        this->initNorms = new Eigen::Vector4f[numPixels];
-        memcpy(this->initNorms, norms, numPixels * sizeof(Eigen::Vector4f));
+      if (!norms.empty()) {
+        this->initNorms = norms;
       }
     }
 
@@ -87,10 +85,6 @@ class Ferns {
       delete[] codes;
 
       if (initRgb) delete[] initRgb;
-
-      if (initVerts) delete[] initVerts;
-
-      if (initNorms) delete[] initNorms;
     }
 
     unsigned char* codes;
@@ -99,8 +93,8 @@ class Ferns {
     Eigen::Matrix4f pose;
     const int srcTime;
     unsigned char* initRgb;
-    Eigen::Vector4f* initVerts;
-    Eigen::Vector4f* initNorms;
+    std::vector<Eigen::Vector4f> initVerts;
+    std::vector<Eigen::Vector4f> initNorms;
   };
 
   std::vector<Frame*> frames;

--- a/Core/Model/Deformation.cpp
+++ b/Core/Model/Deformation.cpp
@@ -25,12 +25,9 @@ Deformation::Deformation()
       sampleProgram(loadProgramGeomFromFile("sample.vert", "sample.geom")),
       bufferSize(1024),  // max nodes basically
       count(0),
-      vertices(new Eigen::Vector4f[bufferSize]),
+      vertices(size_t(bufferSize)),
       graphPosePoints(new std::vector<Eigen::Vector3f>),
       lastDeformTime(0) {
-  // x, y, z and init time
-  memset(&vertices[0], 0, bufferSize);
-
   glGenTransformFeedbacks(1, &fid);
   glGenBuffers(1, &vbo);
   glBindBuffer(GL_ARRAY_BUFFER, vbo);
@@ -51,7 +48,6 @@ Deformation::Deformation()
 }
 
 Deformation::~Deformation() {
-  delete[] vertices;
   glDeleteTransformFeedbacks(1, &fid);
   glDeleteBuffers(1, &vbo);
   glDeleteQueries(1, &countQuery);
@@ -252,7 +248,7 @@ void Deformation::sampleGraphModel(const OutputBuffer& model) {
   if ((int)count > def.k) {
     glBindBuffer(GL_ARRAY_BUFFER, vbo);
 
-    glGetBufferSubData(GL_ARRAY_BUFFER, 0, sizeof(Eigen::Vector4f) * count, vertices);
+    glGetBufferSubData(GL_ARRAY_BUFFER, 0, sizeof(Eigen::Vector4f) * count, vertices.data());
 
     glBindBuffer(GL_ARRAY_BUFFER, 0);
 

--- a/Core/Model/Deformation.h
+++ b/Core/Model/Deformation.h
@@ -76,7 +76,7 @@ class Deformation {
                  /*std::vector<std::pair<unsigned long long int, Eigen::Matrix4f> > & poseGraph,*/
                  const bool relaxGraph, std::vector<Constraint>* newRelativeCons = 0);
 
-  Eigen::Vector4f* getVertices() { return vertices; }
+  Eigen::Vector4f* getVertices() { return vertices.data(); }
 
   int getCount() { return int(count); }
 
@@ -96,7 +96,7 @@ class Deformation {
   const int bufferSize;
   GLuint countQuery;
   unsigned int count;
-  Eigen::Vector4f* vertices;
+  std::vector<Eigen::Vector4f> vertices;  // x, y, z and init time
 
   std::vector<std::pair<uint64_t, Eigen::Vector3f> > poseGraphPoints;
   std::vector<unsigned long long int> graphPoseTimes;

--- a/Core/Segmentation/Segmentation.cpp
+++ b/Core/Segmentation/Segmentation.cpp
@@ -147,7 +147,6 @@ SegmentationResult Segmentation::performSegmentationCRF(std::list<std::shared_pt
   const unsigned lowWidth = result.lowRGB.cols;
   const unsigned lowHeight = result.lowRGB.rows;
   const unsigned lowTotal = result.lowRGB.total();
-  const unsigned fullTotal = frame.rgb.total();
   const unsigned fullWidth = frame.rgb.cols;
   const unsigned fullHeight = frame.rgb.rows;
 

--- a/Core/Segmentation/Slic.h
+++ b/Core/Segmentation/Slic.h
@@ -136,7 +136,7 @@ class Slic {
     assert(input.isContinuous());
     assert(input.total() == spixelNum);
 
-    cv::Mat result = cv::Mat(slicInput->noDims[1], slicInput->noDims[0], cv::DataType<Tout>::type);
+    cv::Mat result = cv::Mat(slicInput->noDims[1], slicInput->noDims[0], cv::traits::Type<Tout>::value);
     Tout* resData = (Tout*)result.data;
     Tin* inData = (Tin*)input.data;
 
@@ -173,7 +173,7 @@ class Slic {
     if (image.type() == CV_8UC3)
       image.copyTo(res);
     else if (image.type() == CV_8UC1)
-      cv::cvtColor(image, res, CV_GRAY2RGB);
+      cv::cvtColor(image, res, cv::COLOR_GRAY2RGB);
     else
       assert(0);
     if (swapRedBlue) cv::cvtColor(res, res, cv::COLOR_RGB2BGR);

--- a/Core/Shaders/FeedbackBuffer.h
+++ b/Core/Shaders/FeedbackBuffer.h
@@ -25,7 +25,7 @@
 #include "../Utils/Resolution.h"
 #include "../Utils/Intrinsics.h"
 #include <pangolin/gl/gl.h>
-#include <pangolin/display/opengl_render_state.h>
+#include <pangolin/gl/opengl_render_state.h>
 
 /// A feedback buffer holds one vertex per pixel (see uvo)
 class FeedbackBuffer {

--- a/GUI/CMakeLists.txt
+++ b/GUI/CMakeLists.txt
@@ -38,7 +38,6 @@ if(CMAKE_BUILD_TYPE MATCHES Debug)
 else(CMAKE_BUILD_TYPE MATCHES Release)
     message(STATUS "Release build.")
     add_compile_options(-O3)
-    add_compile_options(-Wno-maybe-uninitialized)
 endif(CMAKE_BUILD_TYPE MATCHES Debug)
 
 add_definitions(-Dlinux=1)

--- a/GUI/CMakeLists.txt
+++ b/GUI/CMakeLists.txt
@@ -62,9 +62,6 @@ target_link_libraries(CoFusion
                       ${JPEG_LIBRARIES}
 )
 
-# deactivate 'class-memaccess' error for direct memcpy of list of 'Eigen::Vector4f'
-target_compile_options(CoFusion PRIVATE "-Wno-error=class-memaccess")
-
 add_library(CoFusionTools SHARED
             ${tools_srcs})
 

--- a/GUI/MainController.cpp
+++ b/GUI/MainController.cpp
@@ -216,32 +216,32 @@ MainController::MainController(int argc, char* argv[])
   showcaseMode = Parse::get().arg(argc, argv, "-sc", empty) > -1;
   gui = new GUI(logFile.length() == 0, showcaseMode);
 
-  if (Parse::get().arg(argc, argv, "-d", tmpFloat) > -1) gui->depthCutoff->Ref().Set(tmpFloat);
-  if (Parse::get().arg(argc, argv, "-i", tmpFloat) > -1) gui->icpWeight->Ref().Set(tmpFloat);
-  if (Parse::get().arg(argc, argv, "-or", tmpFloat) > -1) gui->outlierCoefficient->Ref().Set(tmpFloat);
-  if (Parse::get().arg(argc, argv, "-segMinNew", tmpFloat) > -1) gui->minRelSizeNew->Ref().Set(tmpFloat);
-  if (Parse::get().arg(argc, argv, "-segMaxNew", tmpFloat) > -1) gui->maxRelSizeNew->Ref().Set(tmpFloat);
-  if (Parse::get().arg(argc, argv, "-crfRGB", tmpFloat) > -1) gui->pairwiseRGBSTD->Ref().Set(tmpFloat);
-  if (Parse::get().arg(argc, argv, "-crfDepth", tmpFloat) > -1) gui->pairwiseDepthSTD->Ref().Set(tmpFloat);
-  if (Parse::get().arg(argc, argv, "-crfPos", tmpFloat) > -1) gui->pairwisePosSTD->Ref().Set(tmpFloat);
-  if (Parse::get().arg(argc, argv, "-crfAppearance", tmpFloat) > -1) gui->pairwiseAppearanceWeight->Ref().Set(tmpFloat);
-  if (Parse::get().arg(argc, argv, "-crfSmooth", tmpFloat) > -1) gui->pairwiseSmoothnessWeight->Ref().Set(tmpFloat);
-  if (Parse::get().arg(argc, argv, "-offset", tmpFloat) > -1) gui->modelSpawnOffset->Ref().Set(tmpFloat);
-  if (Parse::get().arg(argc, argv, "-thNew", tmpFloat) > -1) gui->thresholdNew->Ref().Set(tmpFloat);
-  if (Parse::get().arg(argc, argv, "-k", tmpFloat) > -1) gui->unaryErrorK->Ref().Set(tmpFloat);
+  if (Parse::get().arg(argc, argv, "-d", tmpFloat) > -1) gui->depthCutoff->Ref()->Set(tmpFloat);
+  if (Parse::get().arg(argc, argv, "-i", tmpFloat) > -1) gui->icpWeight->Ref()->Set(tmpFloat);
+  if (Parse::get().arg(argc, argv, "-or", tmpFloat) > -1) gui->outlierCoefficient->Ref()->Set(tmpFloat);
+  if (Parse::get().arg(argc, argv, "-segMinNew", tmpFloat) > -1) gui->minRelSizeNew->Ref()->Set(tmpFloat);
+  if (Parse::get().arg(argc, argv, "-segMaxNew", tmpFloat) > -1) gui->maxRelSizeNew->Ref()->Set(tmpFloat);
+  if (Parse::get().arg(argc, argv, "-crfRGB", tmpFloat) > -1) gui->pairwiseRGBSTD->Ref()->Set(tmpFloat);
+  if (Parse::get().arg(argc, argv, "-crfDepth", tmpFloat) > -1) gui->pairwiseDepthSTD->Ref()->Set(tmpFloat);
+  if (Parse::get().arg(argc, argv, "-crfPos", tmpFloat) > -1) gui->pairwisePosSTD->Ref()->Set(tmpFloat);
+  if (Parse::get().arg(argc, argv, "-crfAppearance", tmpFloat) > -1) gui->pairwiseAppearanceWeight->Ref()->Set(tmpFloat);
+  if (Parse::get().arg(argc, argv, "-crfSmooth", tmpFloat) > -1) gui->pairwiseSmoothnessWeight->Ref()->Set(tmpFloat);
+  if (Parse::get().arg(argc, argv, "-offset", tmpFloat) > -1) gui->modelSpawnOffset->Ref()->Set(tmpFloat);
+  if (Parse::get().arg(argc, argv, "-thNew", tmpFloat) > -1) gui->thresholdNew->Ref()->Set(tmpFloat);
+  if (Parse::get().arg(argc, argv, "-k", tmpFloat) > -1) gui->unaryErrorK->Ref()->Set(tmpFloat);
 
-  gui->flipColors->Ref().Set(logReader->flipColors);
-  gui->rgbOnly->Ref().Set(false);
-  gui->enableMultiModel->Ref().Set(Parse::get().arg(argc, argv, "-static", empty) <= -1);
-  gui->enableSmartDelete->Ref().Set(Parse::get().arg(argc, argv, "-keep", empty) <= -1);
-  gui->pyramid->Ref().Set(true);
-  gui->fastOdom->Ref().Set(fastOdom);
-  // gui->confidenceThreshold->Ref().Set(confidence);
-  gui->so3->Ref().Set(so3);
-  gui->frameToFrameRGB->Ref().Set(frameToFrameRGB);
-  gui->pause->Ref().Set((Parse::get().arg(argc, argv, "-run", empty) <= -1));
-  // gui->pause->Ref().Set(logFile.length());
-  // gui->pause->Ref().Set(!showcaseMode);
+  gui->flipColors->Ref()->Set(logReader->flipColors);
+  gui->rgbOnly->Ref()->Set(false);
+  gui->enableMultiModel->Ref()->Set(Parse::get().arg(argc, argv, "-static", empty) <= -1);
+  gui->enableSmartDelete->Ref()->Set(Parse::get().arg(argc, argv, "-keep", empty) <= -1);
+  gui->pyramid->Ref()->Set(true);
+  gui->fastOdom->Ref()->Set(fastOdom);
+  // gui->confidenceThreshold->Ref()->Set(confidence);
+  gui->so3->Ref()->Set(so3);
+  gui->frameToFrameRGB->Ref()->Set(frameToFrameRGB);
+  gui->pause->Ref()->Set((Parse::get().arg(argc, argv, "-run", empty) <= -1));
+  // gui->pause->Ref()->Set(logFile.length());
+  // gui->pause->Ref()->Set(!showcaseMode);
 
   resizeStream = new GPUResize(Resolution::getInstance().width(), Resolution::getInstance().height(), Resolution::getInstance().width() / 2,
                                Resolution::getInstance().height() / 2);
@@ -388,7 +388,7 @@ void MainController::run() {
         }
 
         if (coFusion->processFrame(logReader->getFrameData(), currentPose, weightMultiplier) && !showcaseMode) {
-          gui->pause->Ref().Set(true);
+          gui->pause->Ref()->Set(true);
         }
 
         if (exportLabels) {
@@ -430,11 +430,11 @@ void MainController::run() {
 
     std::stringstream stri;
     stri << coFusion->getModelToModel().lastICPCount;
-    gui->trackInliers->Ref().Set(stri.str());
+    gui->trackInliers->Ref()->Set(stri.str());
 
     std::stringstream stre;
     stre << (std::isnan(coFusion->getModelToModel().lastICPError) ? 0 : coFusion->getModelToModel().lastICPError);
-    gui->trackRes->Ref().Set(stre.str());
+    gui->trackRes->Ref()->Set(stre.str());
 
     if (!gui->pause->Get()) {
       gui->resLog.Log((std::isnan(coFusion->getModelToModel().lastICPError) ? std::numeric_limits<float>::max()

--- a/GUI/Tools/GUI.h
+++ b/GUI/Tools/GUI.h
@@ -67,12 +67,7 @@ class GUI {
 
     width += widthPanel;
 
-    pangolin::Params windowParams;
-
-    windowParams.Set("SAMPLE_BUFFERS", 0);
-    windowParams.Set("SAMPLES", 0);
-
-    pangolin::CreateWindowAndBind("Co-Fusion", width, height, windowParams);
+    pangolin::CreateWindowAndBind("Co-Fusion", width, height);
 
     glPixelStorei(GL_UNPACK_ALIGNMENT, 1);
     glPixelStorei(GL_PACK_ALIGNMENT, 1);
@@ -260,15 +255,15 @@ class GUI {
       pangolin::RegisterKeyPressCallback(' ', pangolin::SetVarFunctor<bool>("ui.Reset", true));
     }
 
-    pangolin::RegisterKeyPressCallback('p', [&]() { pause->Ref().Set(!pause->Get()); });
-    pangolin::RegisterKeyPressCallback('c', [&]() { drawColors->Ref().Set(!drawColors->Get()); });
-    pangolin::RegisterKeyPressCallback('l', [&]() { drawLabelColors->Ref().Set(!drawLabelColors->Get()); });
-    pangolin::RegisterKeyPressCallback('x', [&]() { drawFxaa->Ref().Set(!drawFxaa->Get()); });
-    pangolin::RegisterKeyPressCallback('f', [&]() { followPose->Ref().Set(!followPose->Get()); });
-    pangolin::RegisterKeyPressCallback('q', [&]() { savePoses->Ref().Set(true); });
-    pangolin::RegisterKeyPressCallback('w', [&]() { saveCloud->Ref().Set(true); });
-    pangolin::RegisterKeyPressCallback('e', [&]() { saveView->Ref().Set(true); });
-    pangolin::RegisterKeyPressCallback('s', [&]() { step->Ref().Set(true); });
+    pangolin::RegisterKeyPressCallback('p', [&]() { pause->Ref()->Set(!pause->Get()); });
+    pangolin::RegisterKeyPressCallback('c', [&]() { drawColors->Ref()->Set(!drawColors->Get()); });
+    pangolin::RegisterKeyPressCallback('l', [&]() { drawLabelColors->Ref()->Set(!drawLabelColors->Get()); });
+    pangolin::RegisterKeyPressCallback('x', [&]() { drawFxaa->Ref()->Set(!drawFxaa->Get()); });
+    pangolin::RegisterKeyPressCallback('f', [&]() { followPose->Ref()->Set(!followPose->Get()); });
+    pangolin::RegisterKeyPressCallback('q', [&]() { savePoses->Ref()->Set(true); });
+    pangolin::RegisterKeyPressCallback('w', [&]() { saveCloud->Ref()->Set(true); });
+    pangolin::RegisterKeyPressCallback('e', [&]() { saveView->Ref()->Set(true); });
+    pangolin::RegisterKeyPressCallback('s', [&]() { step->Ref()->Set(true); });
   }
 
   virtual ~GUI() {

--- a/GUI/Tools/GUI.h
+++ b/GUI/Tools/GUI.h
@@ -72,7 +72,7 @@ class GUI {
     windowParams.Set("SAMPLE_BUFFERS", 0);
     windowParams.Set("SAMPLES", 0);
 
-    pangolin::CreateWindowAndBind("Main", width, height, windowParams);
+    pangolin::CreateWindowAndBind("Co-Fusion", width, height, windowParams);
 
     glPixelStorei(GL_UNPACK_ALIGNMENT, 1);
     glPixelStorei(GL_PACK_ALIGNMENT, 1);

--- a/GUI/Tools/GUI.h
+++ b/GUI/Tools/GUI.h
@@ -268,6 +268,7 @@ class GUI {
     pangolin::RegisterKeyPressCallback('q', [&]() { savePoses->Ref().Set(true); });
     pangolin::RegisterKeyPressCallback('w', [&]() { saveCloud->Ref().Set(true); });
     pangolin::RegisterKeyPressCallback('e', [&]() { saveView->Ref().Set(true); });
+    pangolin::RegisterKeyPressCallback('s', [&]() { step->Ref().Set(true); });
   }
 
   virtual ~GUI() {

--- a/GUI/Tools/GroundTruthOdometry.cpp
+++ b/GUI/Tools/GroundTruthOdometry.cpp
@@ -34,6 +34,9 @@ void GroundTruthOdometry::loadTrajectory(const std::string& filename) {
 
     if (file.eof()) break;
 
+#ifdef NDEBUG
+    (void) n;
+#endif
     assert(n == 8);
 
     Eigen::Quaternionf q(qw, qx, qy, qz);

--- a/GUI/Tools/PangolinReader.cpp
+++ b/GUI/Tools/PangolinReader.cpp
@@ -45,7 +45,7 @@ void PangolinReader::configureConversion(pangolin::StreamInfo& stream, bool& con
   bufferCursor += stream.SizeBytes();
 }
 
-static bool continue_showing = true;
+// static bool continue_showing = true;
 void PangolinReader::getNext() {
   lastFrameRetrieved = true;
   if (!initialized) {

--- a/package.xml
+++ b/package.xml
@@ -48,17 +48,20 @@
   <build_depend>libboost-dev</build_depend>
   <build_depend>pangolin</build_depend>
   <build_depend>suitesparse</build_depend>
+  <build_depend>libopenni2-dev</build_depend>
   <build_export_depend>eigen</build_export_depend>
   <build_export_depend>gslicr</build_export_depend>
   <build_export_depend>libboost-dev</build_export_depend>
   <build_export_depend>pangolin</build_export_depend>
   <build_export_depend>suitesparse</build_export_depend>
+  <build_export_depend>libopenni2-dev</build_export_depend>
   <exec_depend>eigen</exec_depend>
   <exec_depend>gslicr</exec_depend>
   <exec_depend>densecrf</exec_depend>
   <exec_depend>libboost-dev</exec_depend>
   <exec_depend>pangolin</exec_depend>
   <exec_depend>suitesparse</exec_depend>
+  <exec_depend>libopenni2-dev</exec_depend>
 
   <export>
     <build_type>cmake</build_type>

--- a/package.xml
+++ b/package.xml
@@ -43,16 +43,16 @@
   <buildtool_depend>cmake</buildtool_depend>
 
   <build_depend>eigen</build_depend>
-  <build_depend>gSLICr</build_depend>
+  <build_depend>gslicr</build_depend>
   <build_depend>densecrf</build_depend>
   <build_depend>libboost-dev</build_depend>
   <build_depend>pangolin</build_depend>
   <build_export_depend>eigen</build_export_depend>
-  <build_export_depend>gSLICr</build_export_depend>
+  <build_export_depend>gslicr</build_export_depend>
   <build_export_depend>libboost-dev</build_export_depend>
   <build_export_depend>pangolin</build_export_depend>
   <exec_depend>eigen</exec_depend>
-  <exec_depend>gSLICr</exec_depend>
+  <exec_depend>gslicr</exec_depend>
   <exec_depend>densecrf</exec_depend>
   <exec_depend>libboost-dev</exec_depend>
   <exec_depend>pangolin</exec_depend>

--- a/package.xml
+++ b/package.xml
@@ -47,15 +47,18 @@
   <build_depend>densecrf</build_depend>
   <build_depend>libboost-dev</build_depend>
   <build_depend>pangolin</build_depend>
+  <build_depend>suitesparse</build_depend>
   <build_export_depend>eigen</build_export_depend>
   <build_export_depend>gslicr</build_export_depend>
   <build_export_depend>libboost-dev</build_export_depend>
   <build_export_depend>pangolin</build_export_depend>
+  <build_export_depend>suitesparse</build_export_depend>
   <exec_depend>eigen</exec_depend>
   <exec_depend>gslicr</exec_depend>
   <exec_depend>densecrf</exec_depend>
   <exec_depend>libboost-dev</exec_depend>
   <exec_depend>pangolin</exec_depend>
+  <exec_depend>suitesparse</exec_depend>
 
   <export>
     <build_type>cmake</build_type>


### PR DESCRIPTION
This PR enables some additional warnings as errors and fixes some of these errors (`deprecated`, `class-memaccess`, `unused-variable`) by replacing C arrays by STL vectors and the deprecated CUDA function `__shfl_down` with `__shfl_down_sync`.

I am getting the same results on a simple test sequence. I guess many changes to the `Ferns` and `Deformation` files are actually not actively used in Co-Fusion.